### PR TITLE
Passwörter entfernen

### DIFF
--- a/cloud_secret.yaml
+++ b/cloud_secret.yaml
@@ -9,6 +9,6 @@ metadata:
   namespace: cloud
   name: mariadb-secret
 stringData:
-  rootpassword: secret123password456
-  userpassword: user1password2cloud
+  rootpassword: INSERT_PASSWORD_HERE
+  userpassword: INSERT_PASSWORD_HERE
 

--- a/dyndns-secret.sample.yaml
+++ b/dyndns-secret.sample.yaml
@@ -5,4 +5,4 @@ metadata:
   name: dyndns-secret
 stringData:
   hostname: cloud.au-lab.de
-  password: xyzSecret123xyz
+  password: INSERT_PASSWORD_HERE


### PR DESCRIPTION
Die Passwörter waren sowieso keine "echten" Passwörter, sahen aber so aus. Durch das Entfernen kommt hoffentlich niemand auf die Idee, sie einfach so zu lassen...